### PR TITLE
wrong phoenix version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PhoenixStarter.Mixfile do
     [
       app: :phoenix_starter,
       version: "0.0.1",
-      elixir: "~> 1.3",
+      elixir: "~> 1.2",
       elixirc_paths: elixirc_paths(Mix.env),
       compilers: [:phoenix, :gettext] ++ Mix.compilers,
       build_embedded: Mix.env == :prod,


### PR DESCRIPTION
in `mix.lock` you specify phoenix version `1.2.1` but in `mix.exs` you require 1.3 or newer which results in an error when running the app...
